### PR TITLE
v1.2.0 Release

### DIFF
--- a/content/content-items/Content/00 Experience Content/05 Externally Referenced Products/Dynamic Product Grid - Accessories.json.hbs
+++ b/content/content-items/Content/00 Experience Content/05 Externally Referenced Products/Dynamic Product Grid - Accessories.json.hbs
@@ -6,7 +6,7 @@
       "schema": "https://demostore.amplience.com/content/product-grid"
     },
     "query": "DKNY",
-    "category": "sale",
+    "category": "d38cf3e8-492a-4da1-ad29-945faae3afbd",
     "limit": 12
   },
   "label": "Dynamic Product Grid - Accessories",

--- a/content/content-items/Content/00 Experience Content/05 Externally Referenced Products/Dynamic Product Grid - Mens Category.json.hbs
+++ b/content/content-items/Content/00 Experience Content/05 Externally Referenced Products/Dynamic Product Grid - Mens Category.json.hbs
@@ -5,7 +5,7 @@
       "name": "Dynamic Product Grid - Mens Category",
       "schema": "https://demostore.amplience.com/content/product-grid"
     },
-    "category": "men",
+    "category": "f1db5156-acfd-4613-be7c-05a634becdc3",
     "limit": 12,
     "query": "Sneakers"
   },

--- a/content/content-items/Content/00 Experience Content/05 Externally Referenced Products/Dynamic Product Grid - Womens Category.json.hbs
+++ b/content/content-items/Content/00 Experience Content/05 Externally Referenced Products/Dynamic Product Grid - Womens Category.json.hbs
@@ -5,7 +5,7 @@
       "name": "Dynamic Product Grid - Womens Category",
       "schema": "https://demostore.amplience.com/content/product-grid"
     },
-    "category": "women",
+    "category": "81cf879f-5597-4c48-8706-f0fc58733313",
     "limit": 12
   },
   "label": "Dynamic Product Grid - Womens Category",

--- a/content/content-items/Site Components/Accessories.json.hbs
+++ b/content/content-items/Site Components/Accessories.json.hbs
@@ -15,7 +15,7 @@
       "priority": 9
     },
     "title": "Accessories",
-    "name": "accessories",
+    "name": "d4be6a31-8c0d-4003-858f-9cf135775e16",
     "slots": [
       {
         "_meta": {

--- a/content/content-items/Site Components/Men.json.hbs
+++ b/content/content-items/Site Components/Men.json.hbs
@@ -22,7 +22,7 @@
       }
     },
     "title": "Men",
-    "name": "men",
+    "name": "f1db5156-acfd-4613-be7c-05a634becdc3",
     "slots": [
       {
         "_meta": {

--- a/content/content-items/Site Components/New.json.hbs
+++ b/content/content-items/Site Components/New.json.hbs
@@ -15,7 +15,7 @@
       "priority": 11
     },
     "title": "New",
-    "name": "new",
+    "name": "aaf18057-02db-481a-9bf6-1d50c0c2298a",
     "slots": [
       {
         "_meta": {

--- a/content/content-items/Site Components/Sale.json.hbs
+++ b/content/content-items/Site Components/Sale.json.hbs
@@ -15,7 +15,7 @@
       "priority": 13
     },
     "title": "Sale",
-    "name": "sale",
+    "name": "d38cf3e8-492a-4da1-ad29-945faae3afbd",
     "slots": [
       {
         "_meta": {

--- a/content/content-items/Site Components/Women.json.hbs
+++ b/content/content-items/Site Components/Women.json.hbs
@@ -22,7 +22,7 @@
       }
     },
     "title": "Women",
-    "name": "women",
+    "name": "81cf879f-5597-4c48-8706-f0fc58733313",
     "slots": [
       {
         "_meta": {

--- a/content/content-type-schemas/schemas/category-experience-schema.json.hbs
+++ b/content/content-type-schemas/schemas/category-experience-schema.json.hbs
@@ -46,8 +46,17 @@
 	"type": "object",
 	"properties": {
 		"id": {
-			"type": "string",
-			"title": "Category ID"
+			"title": "Ecommerce Category",
+            "description": "The eCommerce category that this experience relates to",
+			"ui:extension": {
+                "name": "ecomm-toolkit",
+                "params": {
+                    "label": "Linked Category",
+                    "view": "single",
+                    "data": "category",
+                    "type": "string"
+                }
+            }
 		},
 		"priority": {
 			"type": "number",

--- a/content/content-type-schemas/schemas/curated-product-grid-schema.json.hbs
+++ b/content/content-type-schemas/schemas/curated-product-grid-schema.json.hbs
@@ -21,7 +21,13 @@
         "type": "string"
       },
       "ui:extension": {
-        "name": "product-selector-rest"
+        "name": "ecomm-toolkit",
+				"params": {
+					"label": "Search By Category",
+					"view": "product",
+					"data": "product",
+					"type": "strings"
+				}
       }
     },
     "header": {

--- a/content/content-type-schemas/schemas/page-category-schema.json.hbs
+++ b/content/content-type-schemas/schemas/page-category-schema.json.hbs
@@ -27,12 +27,12 @@
 	"type": "object",
 	"properties": {
         "_meta": {
-            "title": "CMS Category Slug",
+            "title": "CMS Category URL",
             "properties": {
                 "deliveryKey": {
-                    "title": "Slug",
+                    "title": "URL",
                     "type": "string",
-                    "description": "Slug of the page URL in the app",
+                    "description": "URL of the page in the application",
                     "pattern": "category\/.*"
                 }
             },
@@ -42,8 +42,17 @@
         },
         "name": {
             "type": "string",
-            "title": "Ecommerce Category Slug",
-            "description": "Slug of the ecommerce category (i.e., 'womens', not 'Womens')"
+            "title": "Ecommerce Category",
+            "description": "The eCommerce category that will be displayed on this page",
+            "ui:extension": {
+                "name": "ecomm-toolkit",
+                "params": {
+                    "label": "Linked Category",
+                    "view": "single",
+                    "data": "category",
+                    "type": "string"
+                }
+            }
         },
         "hideProductList": {
             "title": "Hide Product List",

--- a/content/content-type-schemas/schemas/page-category-schema.json.hbs
+++ b/content/content-type-schemas/schemas/page-category-schema.json.hbs
@@ -27,7 +27,7 @@
 	"type": "object",
 	"properties": {
         "_meta": {
-            "title": "CMS Category URL",
+            "title": "Page URL",
             "properties": {
                 "deliveryKey": {
                     "title": "URL",

--- a/content/content-type-schemas/schemas/page-category-schema.json.hbs
+++ b/content/content-type-schemas/schemas/page-category-schema.json.hbs
@@ -44,6 +44,7 @@
             "type": "string",
             "title": "Ecommerce Category",
             "description": "The eCommerce category that will be displayed on this page",
+            "pattern":"^(?!\\s*$).+",
             "ui:extension": {
                 "name": "ecomm-toolkit",
                 "params": {

--- a/content/content-type-schemas/schemas/page-category-schema.json.hbs
+++ b/content/content-type-schemas/schemas/page-category-schema.json.hbs
@@ -44,7 +44,6 @@
             "type": "string",
             "title": "Ecommerce Category",
             "description": "The eCommerce category that will be displayed on this page",
-            "pattern":"^(?!\\s*$).+",
             "ui:extension": {
                 "name": "ecomm-toolkit",
                 "params": {

--- a/content/content-type-schemas/schemas/product-experience-schema.json.hbs
+++ b/content/content-type-schemas/schemas/product-experience-schema.json.hbs
@@ -45,7 +45,17 @@
 	"properties": {
 		"id": {
 			"type": "string",
-			"title": "Product ID"
+			"title": "Ecommerce Product",
+			"description": "The eCommerce product that this experience relates to",
+			"ui:extension": {
+				"name": "ecomm-toolkit",
+				"params": {
+				"label": "Search By Category",
+				"view": "product",
+				"data": "product",
+				"type": "string"
+				}
+			}
 		},
 		"priority": {
 			"type": "number",

--- a/content/content-type-schemas/schemas/product-grid-schema.json.hbs
+++ b/content/content-type-schemas/schemas/product-grid-schema.json.hbs
@@ -20,16 +20,17 @@
 		},
 		"category": {
 			"title": "Product Category",
-			"description": "",
+			"description": "The product category used to to render",
 			"type": "string",
-			"enum": [
-				"kids",
-				"men",
-				"women",
-				"sale",
-				"women-new_arrivals",
-				"men-new_arrivals"
-			]
+			"ui:extension": {
+                "name": "ecomm-toolkit",
+                "params": {
+                    "label": "Linked Category",
+                    "view": "single",
+                    "data": "category",
+                    "type": "string"
+                }
+            }
 		},
 
 		"limit": {

--- a/content/content-type-schemas/schemas/product-schema.json.hbs
+++ b/content/content-type-schemas/schemas/product-schema.json.hbs
@@ -20,7 +20,16 @@
                     "title": "Delivery Key",
                     "description": "product/productId",
                     "type": "string",
-                    "pattern": "product\/.*"
+                    "pattern": "product\/.*",
+                    "ui:extension": {
+                      "name": "ecomm-toolkit",
+                      "params": {
+                        "label": "Search By Category",
+                        "view": "product",
+                        "data": "product",
+                        "type": "string"
+                      }
+                    }
                 }
             },
             "required": [

--- a/content/extensions/extensions.json.hbs
+++ b/content/extensions/extensions.json.hbs
@@ -154,6 +154,59 @@
       "status": "ACTIVE"
     },
     {
+      "name": "ecomm-toolkit",
+      "label": "eCommerce Toolkit",
+      "description": "Interfaces with core eComm elements like product, categories, segments",
+      "url": "https://dc-extension-ecomm-toolkit.vercel.app/",
+      "height": 200,
+      "category": "CONTENT_FIELD",
+      "parameters" : "{\n  \"vendor\": \"rest\",\n  \"codec_params\": {\n    \"productURL\": \"https://demostore-catalog.s3.us-east-2.amazonaws.com/products.json\",\n    \"categoryURL\": \"https://demostore-catalog.s3.us-east-2.amazonaws.com/categories.json\",\n    \"customerGroupURL\": \"https://demostore-catalog.s3.us-east-2.amazonaws.com/customerGroups.json\",\n    \"translationsURL\": \"https://demostore-catalog.s3.us-east-2.amazonaws.com/translations.json\"\n  }\n}",
+      "snippets": [
+        {
+            "label": "User Segments - Multi select - object",
+            "body": "{\n  \"title\": \"User Segments\",\n  \"description\": \"Multi-select User Segments and store as {name:string,id:string}\",\n  \"type\": \"array\",\n  \"minItems\": 0,\n  \"maxItems\": 5,\n  \"items\": {\n    \"type\": \"object\",\n    \"properties\": {\n      \"id\": {\n        \"title\": \"ID\",\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"title\": \"Name\",\n        \"type\": \"string\"\n      }\n    }\n  },\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"User Segments\",\n      \"view\": \"multi\",\n      \"data\": \"segment\",\n      \"type\": \"object\"\n    }\n  }\n}"
+        },
+        {
+            "label": "User Segments - Multi select - string",
+            "body": "{\n  \"title\": \"User Groups\",\n  \"description\": \"Multi-select User Segments and store as string\",\n  \"type\": \"array\",\n  \"minItems\": 0,\n  \"maxItems\": 5,\n  \"items\": {\n    \"type\": \"string\"\n  },\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"User Segments\",\n      \"view\": \"multi\",\n      \"data\": \"segment\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Category - Single Select - object",
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store Name,ID as {name:string,id:string}\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": {\n      \"title\": \"Name\",\n      \"type\": \"string\"\n    },\n    \"id\": {\n      \"title\": \"ID\",\n      \"type\": \"string\"\n    }\n  },\n  \"propertyOrder\": [\n    \"id\",\n    \"name\"\n  ],\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"object\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Category - Single Select - string",
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Category - Single Select - enforced string",
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"category/.*\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Category - Single Select Tree - string",
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category Tree and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"tree\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Category - Single Select Tree - enforced string",
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category Tree and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"category/.*\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"tree\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Product Selector - Single String",
+            "body": "{\n  \"title\": \"Product Selector (string)\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Search By Category\",\n      \"view\": \"product\",\n      \"data\": \"product\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Product Selector - Single Enforced String",
+            "body": "{\n  \"title\": \"Product Selector (string)\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"pdp/content/.*\",\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Search By Category\",\n      \"view\": \"product\",\n      \"data\": \"product\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Product Selector -  ID String Array",
+            "body": "{\n  \"title\": \"Product Selector (strings)\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"array\",\n  \"items\": {\n    \"type\": \"string\"\n  },\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Search By Category\",\n      \"view\": \"product\",\n      \"data\": \"product\",\n      \"type\": \"strings\"\n    }\n  }\n}"
+        }
+    ],
+      "settings": "{\"API\":{\"READ\":true,\"EDIT\":true},\"SANDBOX\":{\"SAME_ORIGIN\":true,\"MODALS\":false,\"NAVIGATION\":false,\"POPUPS\":false,\"POPUP_ESCAPE_SANDBOX\":false,\"DOWNLOADS\":false,\"FORMS\":false}}",
+      "status": "ACTIVE"
+    },
+    {
       "name": "deep-copy",
       "label": "Deep Copy",
       "description": "Dashboard extension which enables customers to copy nested content items",

--- a/content/extensions/extensions.json.hbs
+++ b/content/extensions/extensions.json.hbs
@@ -100,16 +100,57 @@
       "settings": null,
       "status": "ACTIVE"
   },
-  {
-      "name": "product-selector-rest",
-      "label": "REST product selector",
-      "description": "REST product selector",
-      "url": "https://productselector.amprsa.net",
+    {
+      "name": "ecomm-toolkit",
+      "label": "eCommerce Toolkit",
+      "description": "Interfaces with core eComm elements like product, categories, segments",
+      "url": "https://dc-extension-ecomm-toolkit.vercel.app/",
       "height": 200,
       "category": "CONTENT_FIELD",
-      "parameters": "{\n  \"apiBaseUrl\": \"{{url}}/api\" \n}",
-      "snippets": [],
-      "settings": null,
+      "parameters" : "{\n  \"vendor\": \"rest\",\n  \"codec_params\": {\n    \"productURL\": \"https://demostore-catalog.s3.us-east-2.amazonaws.com/products.json\",\n    \"categoryURL\": \"https://demostore-catalog.s3.us-east-2.amazonaws.com/categories.json\",\n    \"customerGroupURL\": \"https://demostore-catalog.s3.us-east-2.amazonaws.com/customerGroups.json\",\n    \"translationsURL\": \"https://demostore-catalog.s3.us-east-2.amazonaws.com/translations.json\"\n  }\n}",
+      "snippets": [
+        {
+            "label": "User Segments - Multi select - object",
+            "body": "{\n  \"title\": \"User Segments\",\n  \"description\": \"Multi-select User Segments and store as {name:string,id:string}\",\n  \"type\": \"array\",\n  \"minItems\": 0,\n  \"maxItems\": 5,\n  \"items\": {\n    \"type\": \"object\",\n    \"properties\": {\n      \"id\": {\n        \"title\": \"ID\",\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"title\": \"Name\",\n        \"type\": \"string\"\n      }\n    }\n  },\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"User Segments\",\n      \"view\": \"multi\",\n      \"data\": \"segment\",\n      \"type\": \"object\"\n    }\n  }\n}"
+        },
+        {
+            "label": "User Segments - Multi select - string",
+            "body": "{\n  \"title\": \"User Groups\",\n  \"description\": \"Multi-select User Segments and store as string\",\n  \"type\": \"array\",\n  \"minItems\": 0,\n  \"maxItems\": 5,\n  \"items\": {\n    \"type\": \"string\"\n  },\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"User Segments\",\n      \"view\": \"multi\",\n      \"data\": \"segment\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Category - Single Select - object",
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store Name,ID as {name:string,id:string}\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": {\n      \"title\": \"Name\",\n      \"type\": \"string\"\n    },\n    \"id\": {\n      \"title\": \"ID\",\n      \"type\": \"string\"\n    }\n  },\n  \"propertyOrder\": [\n    \"id\",\n    \"name\"\n  ],\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"object\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Category - Single Select - string",
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Category - Single Select - enforced string",
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"category/.*\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Category - Single Select Tree - string",
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category Tree and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"tree\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Category - Single Select Tree - enforced string",
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category Tree and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"category/.*\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"tree\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Product Selector - Single String",
+            "body": "{\n  \"title\": \"Product Selector (string)\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Search By Category\",\n      \"view\": \"product\",\n      \"data\": \"product\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Product Selector - Single Enforced String",
+            "body": "{\n  \"title\": \"Product Selector (string)\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"pdp/content/.*\",\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Search By Category\",\n      \"view\": \"product\",\n      \"data\": \"product\",\n      \"type\": \"string\"\n    }\n  }\n}"
+        },
+        {
+            "label": "Product Selector -  ID String Array",
+            "body": "{\n  \"title\": \"Product Selector (strings)\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"array\",\n  \"items\": {\n    \"type\": \"string\"\n  },\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Search By Category\",\n      \"view\": \"product\",\n      \"data\": \"product\",\n      \"type\": \"strings\"\n    }\n  }\n}"
+        }
+    ],
+      "settings": "{\"API\":{\"READ\":true,\"EDIT\":true},\"SANDBOX\":{\"SAME_ORIGIN\":true,\"MODALS\":false,\"NAVIGATION\":false,\"POPUPS\":false,\"POPUP_ESCAPE_SANDBOX\":false,\"DOWNLOADS\":false,\"FORMS\":false}}",
       "status": "ACTIVE"
     },
     {

--- a/content/extensions/extensions.json.hbs
+++ b/content/extensions/extensions.json.hbs
@@ -111,31 +111,31 @@
       "snippets": [
         {
             "label": "User Segments - Multi select - object",
-            "body": "{\n  \"title\": \"User Segments\",\n  \"description\": \"Multi-select User Segments and store as {name:string,id:string}\",\n  \"type\": \"array\",\n  \"minItems\": 0,\n  \"maxItems\": 5,\n  \"items\": {\n    \"type\": \"object\",\n    \"properties\": {\n      \"id\": {\n        \"title\": \"ID\",\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"title\": \"Name\",\n        \"type\": \"string\"\n      }\n    }\n  },\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"User Segments\",\n      \"view\": \"multi\",\n      \"data\": \"segment\",\n      \"type\": \"object\"\n    }\n  }\n}"
+            "body": "{\n  \"title\": \"User Segments\",\n  \"description\": \"Multi-select User Segments and store as {name:string,id:string}\",\n  \"type\": \"array\",\n  \"minItems\": 0,\n  \"maxItems\": 5,\n  \"items\": {\n    \"type\": \"object\",\n    \"properties\": {\n      \"id\": {\n        \"title\": \"ID\",\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"title\": \"Name\",\n        \"type\": \"string\"\n      }\n    }\n  },\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"User Segments\",\n      \"view\": \"multi\",\n      \"data\": \"segment\",\n      \"type\": \"object\"\n    }\n  }\n}"
         },
         {
             "label": "User Segments - Multi select - string",
-            "body": "{\n  \"title\": \"User Groups\",\n  \"description\": \"Multi-select User Segments and store as string\",\n  \"type\": \"array\",\n  \"minItems\": 0,\n  \"maxItems\": 5,\n  \"items\": {\n    \"type\": \"string\"\n  },\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"User Segments\",\n      \"view\": \"multi\",\n      \"data\": \"segment\",\n      \"type\": \"string\"\n    }\n  }\n}"
+            "body": "{\n  \"title\": \"User Groups\",\n  \"description\": \"Multi-select User Segments and store as string\",\n  \"type\": \"array\",\n  \"minItems\": 0,\n  \"maxItems\": 5,\n  \"items\": {\n    \"type\": \"string\"\n  },\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"User Segments\",\n      \"view\": \"multi\",\n      \"data\": \"segment\",\n      \"type\": \"string\"\n    }\n  }\n}"
         },
         {
             "label": "Category - Single Select - object",
-            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store Name,ID as {name:string,id:string}\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": {\n      \"title\": \"Name\",\n      \"type\": \"string\"\n    },\n    \"id\": {\n      \"title\": \"ID\",\n      \"type\": \"string\"\n    }\n  },\n  \"propertyOrder\": [\n    \"id\",\n    \"name\"\n  ],\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"object\"\n    }\n  }\n}"
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store Name,ID as {name:string,id:string}\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": {\n      \"title\": \"Name\",\n      \"type\": \"string\"\n    },\n    \"id\": {\n      \"title\": \"ID\",\n      \"type\": \"string\"\n    }\n  },\n  \"propertyOrder\": [\n    \"id\",\n    \"name\"\n  ],\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"object\"\n    }\n  }\n}"
         },
         {
             "label": "Category - Single Select - string",
-            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
         },
         {
             "label": "Category - Single Select - enforced string",
-            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"category/.*\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"category/.*\",\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
         },
         {
             "label": "Category - Single Select Tree - string",
-            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category Tree and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"tree\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category Tree and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"tree\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
         },
         {
             "label": "Category - Single Select Tree - enforced string",
-            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category Tree and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"category/.*\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"tree\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
+            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category Tree and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"category/.*\",\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"tree\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
         },
         {
             "label": "Product Selector - Single String",

--- a/content/extensions/extensions.json.hbs
+++ b/content/extensions/extensions.json.hbs
@@ -154,59 +154,6 @@
       "status": "ACTIVE"
     },
     {
-      "name": "ecomm-toolkit",
-      "label": "eCommerce Toolkit",
-      "description": "Interfaces with core eComm elements like product, categories, segments",
-      "url": "https://dc-extension-ecomm-toolkit.vercel.app/",
-      "height": 200,
-      "category": "CONTENT_FIELD",
-      "parameters" : "{\n  \"vendor\": \"rest\",\n  \"codec_params\": {\n    \"productURL\": \"https://demostore-catalog.s3.us-east-2.amazonaws.com/products.json\",\n    \"categoryURL\": \"https://demostore-catalog.s3.us-east-2.amazonaws.com/categories.json\",\n    \"customerGroupURL\": \"https://demostore-catalog.s3.us-east-2.amazonaws.com/customerGroups.json\",\n    \"translationsURL\": \"https://demostore-catalog.s3.us-east-2.amazonaws.com/translations.json\"\n  }\n}",
-      "snippets": [
-        {
-            "label": "User Segments - Multi select - object",
-            "body": "{\n  \"title\": \"User Segments\",\n  \"description\": \"Multi-select User Segments and store as {name:string,id:string}\",\n  \"type\": \"array\",\n  \"minItems\": 0,\n  \"maxItems\": 5,\n  \"items\": {\n    \"type\": \"object\",\n    \"properties\": {\n      \"id\": {\n        \"title\": \"ID\",\n        \"type\": \"string\"\n      },\n      \"name\": {\n        \"title\": \"Name\",\n        \"type\": \"string\"\n      }\n    }\n  },\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"User Segments\",\n      \"view\": \"multi\",\n      \"data\": \"segment\",\n      \"type\": \"object\"\n    }\n  }\n}"
-        },
-        {
-            "label": "User Segments - Multi select - string",
-            "body": "{\n  \"title\": \"User Groups\",\n  \"description\": \"Multi-select User Segments and store as string\",\n  \"type\": \"array\",\n  \"minItems\": 0,\n  \"maxItems\": 5,\n  \"items\": {\n    \"type\": \"string\"\n  },\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"User Segments\",\n      \"view\": \"multi\",\n      \"data\": \"segment\",\n      \"type\": \"string\"\n    }\n  }\n}"
-        },
-        {
-            "label": "Category - Single Select - object",
-            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store Name,ID as {name:string,id:string}\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"name\": {\n      \"title\": \"Name\",\n      \"type\": \"string\"\n    },\n    \"id\": {\n      \"title\": \"ID\",\n      \"type\": \"string\"\n    }\n  },\n  \"propertyOrder\": [\n    \"id\",\n    \"name\"\n  ],\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"object\"\n    }\n  }\n}"
-        },
-        {
-            "label": "Category - Single Select - string",
-            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
-        },
-        {
-            "label": "Category - Single Select - enforced string",
-            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"category/.*\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"single\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
-        },
-        {
-            "label": "Category - Single Select Tree - string",
-            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category Tree and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"tree\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
-        },
-        {
-            "label": "Category - Single Select Tree - enforced string",
-            "body": "{\n  \"title\": \"Category\",\n  \"description\": \"Single-select Category Tree and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"category/.*\",\n  \"ui:extension\": {\n    \"name\": \"swiss-army-knife\",\n    \"params\": {\n      \"label\": \"Category\",\n      \"view\": \"tree\",\n      \"data\": \"category\",\n      \"type\": \"string\"\n    }\n  }\n}"
-        },
-        {
-            "label": "Product Selector - Single String",
-            "body": "{\n  \"title\": \"Product Selector (string)\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Search By Category\",\n      \"view\": \"product\",\n      \"data\": \"product\",\n      \"type\": \"string\"\n    }\n  }\n}"
-        },
-        {
-            "label": "Product Selector - Single Enforced String",
-            "body": "{\n  \"title\": \"Product Selector (string)\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"string\",\n  \"pattern\": \"pdp/content/.*\",\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Search By Category\",\n      \"view\": \"product\",\n      \"data\": \"product\",\n      \"type\": \"string\"\n    }\n  }\n}"
-        },
-        {
-            "label": "Product Selector -  ID String Array",
-            "body": "{\n  \"title\": \"Product Selector (strings)\",\n  \"description\": \"Single-select Category and store ID as string\",\n  \"type\": \"array\",\n  \"items\": {\n    \"type\": \"string\"\n  },\n  \"ui:extension\": {\n    \"name\": \"ecomm-toolkit\",\n    \"params\": {\n      \"label\": \"Search By Category\",\n      \"view\": \"product\",\n      \"data\": \"product\",\n      \"type\": \"strings\"\n    }\n  }\n}"
-        }
-    ],
-      "settings": "{\"API\":{\"READ\":true,\"EDIT\":true},\"SANDBOX\":{\"SAME_ORIGIN\":true,\"MODALS\":false,\"NAVIGATION\":false,\"POPUPS\":false,\"POPUP_ESCAPE_SANDBOX\":false,\"DOWNLOADS\":false,\"FORMS\":false}}",
-      "status": "ACTIVE"
-    },
-    {
       "name": "deep-copy",
       "label": "Deep Copy",
       "description": "Dashboard extension which enables customers to copy nested content items",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amplience/dc-demostore-automation",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": false,
   "keywords": [
     "amplience",


### PR DESCRIPTION
- **Extensions** - Added eComm Toolkit and removed custom product selector (REST)

- **Components** - Updates as per above to use new extension

- **Content** - Any content that was previously storing a ‘slug’ has been changed to store the ‘id’.